### PR TITLE
Leave usage of fonts up to implementor

### DIFF
--- a/friggeri-cv.cls
+++ b/friggeri-cv.cls
@@ -45,19 +45,10 @@
 % Fonts %
 %%%%%%%%%
 
-\RequirePackage[quiet]{fontspec}
 \RequirePackage[math-style=TeX]{unicode-math}
 
 \RequirePackage[activate={true,nocompatibility},final,factor=1100,stretch=10,shrink=10,expansion=false,verbose=silent]{microtype}
 
-\newfontfamily\bodyfont[]{Helvetica Neue}
-\newfontfamily\thinfont[]{Helvetica Neue UltraLight}
-\newfontfamily\headingfont[]{Helvetica Neue Condensed Bold}
-
-\defaultfontfeatures{Mapping=tex-text}
-\setmainfont[Mapping=tex-text, Color=textcolor]{Helvetica Neue Light}
-
-\setmathfont{XITS Math}
 \RequirePackage{xltxtra}
 
 %%%%%%%%%%
@@ -181,8 +172,6 @@
 %%%%%%%%%%%%%%%%
 % Social icons %
 %%%%%%%%%%%%%%%%
-
-\RequirePackage{fontawesome}
 
 % Add instagram logo to fontawesome
 \expandafter\def\csname faicon@instagram\endcsname           {\symbol{"F16D}}  \def\faInstagramSquare {{\FA\csname faicon@instagram\endcsname}}


### PR DESCRIPTION
This PR allows the user of this package to define the fonts they would like to use within their document, instead of it being hardcoded here.

Companion PR to this can be found here: https://github.com/martinbjeldbak/CV/pull/2/files for an example of how this package is now used.